### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/services/googleMapsService.ts
+++ b/src/services/googleMapsService.ts
@@ -454,9 +454,19 @@ export class GoogleMapsService {
     // Analyze website for booking platforms
     if (website) {
       const url = website.toLowerCase();
+      let hostname = '';
+      try {
+        hostname = new URL(website).hostname.toLowerCase();
+      } catch (e) {
+        // If website is not a valid URL, fallback to substring checks (optional)
+        hostname = '';
+      }
 
       // OpenTable detection
-      if (url.includes('opentable.com') || url.includes('opentable')) {
+      if (
+        hostname === 'opentable.com' ||
+        hostname.endsWith('.opentable.com')
+      ) {
         return {
           ...bookingInfo,
           reservable: true,
@@ -468,7 +478,10 @@ export class GoogleMapsService {
       }
 
       // Resy detection
-      if (url.includes('resy.com') || url.includes('resy')) {
+      if (
+        hostname === 'resy.com' ||
+        hostname.endsWith('.resy.com')
+      ) {
         return {
           ...bookingInfo,
           reservable: true,
@@ -481,7 +494,7 @@ export class GoogleMapsService {
 
       // Yelp reservations detection
       if (
-        url.includes('yelp.com') &&
+        (hostname === 'yelp.com' || hostname.endsWith('.yelp.com')) &&
         (url.includes('reservations') || url.includes('book'))
       ) {
         return {
@@ -496,8 +509,8 @@ export class GoogleMapsService {
 
       // Google Reserve detection
       if (
-        url.includes('reserve.google.com') ||
-        url.includes('google.com/reserve')
+        hostname === 'reserve.google.com' ||
+        (hostname === 'google.com' && url.includes('/reserve'))
       ) {
         return {
           ...bookingInfo,


### PR DESCRIPTION
Potential fix for [https://github.com/samwang0723/mcp-booking/security/code-scanning/4](https://github.com/samwang0723/mcp-booking/security/code-scanning/4)

To fix the problem, the code should parse the URL and check the host (domain) component rather than using substring checks. This ensures that only URLs with the correct domain (e.g., `yelp.com`, `opentable.com`, `resy.com`, etc.) are matched, and subdomain handling can be made explicit. The best way to do this in Node.js/TypeScript is to use the built-in `URL` class to parse the URL and then check the `host` or `hostname` property. The changes should be made in the region where substring checks are performed (lines 456–523), replacing them with host-based checks. An import of the built-in `url` module is not necessary; the global `URL` class can be used. The fix should handle possible exceptions if the URL is invalid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
